### PR TITLE
Fix java lesson04 Formatter/Publisher reporting to Jaeger.

### DIFF
--- a/java/src/main/java/lesson04/solution/Formatter.java
+++ b/java/src/main/java/lesson04/solution/Formatter.java
@@ -56,8 +56,6 @@ public class Formatter extends Application<Configuration> {
     public static void main(String[] args) throws Exception {
         System.setProperty("dw.server.applicationConnectors[0].port", "8081");
         System.setProperty("dw.server.adminConnectors[0].port", "9081");
-        try (JaegerTracer tracer = Tracing.init("formatter")) {
-            new Formatter(tracer).run(args);
-        }
+        new Formatter(Tracing.init("formatter")).run(args);
     }
 }

--- a/java/src/main/java/lesson04/solution/Publisher.java
+++ b/java/src/main/java/lesson04/solution/Publisher.java
@@ -52,8 +52,6 @@ public class Publisher extends Application<Configuration> {
     public static void main(String[] args) throws Exception {
         System.setProperty("dw.server.applicationConnectors[0].port", "8082");
         System.setProperty("dw.server.adminConnectors[0].port", "9082");
-        try (JaegerTracer tracer = Tracing.init("publisher")) {
-            new Publisher(tracer).run(args);
-        }
+        new Publisher(Tracing.init("publisher")).run(args);
     }
 }


### PR DESCRIPTION
* The difference between the java/lesson03 solution and lesson4 is the
  JaegerTracer is initilized before the Dropwizard server, in the latter.
* This results in the RemoteReporter-QueueProcessor (and FlushTimer)
  thread getting killed by the Dropwizard server when it starts later.
* Thus, Jaeger spans are not reported to port 6831 by the lesson04
  Publisher/Formatter.
* Fix by reverting to the lesson03 pattern for startup.
* Explicitly calling close() on the JaegerTracer is not necessary since
  it registers a shutdownHook.